### PR TITLE
Add multi-distro repository tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /secrets
+*.part

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-## The Offical Playit PPA
+## Official playit Package Repositories
 
-To install playit on a debian based operating system simply run
+### Debian / Ubuntu
+
+To install playit on a Debian-based operating system, run:
 
 ```
 curl -SsL https://playit-cloud.github.io/ppa/key.gpg | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/playit.gpg >/dev/null
@@ -9,7 +11,7 @@ sudo apt update
 sudo apt install playit
 ```
 
-Getting a warning in apt about playit's repo? Run these commands
+Getting a warning in apt about playit's repo? Run these commands:
 
 ```
 sudo apt-key del '16AC CC32 BD41 5DCC 6F00  D548 DA6C D75E C283 9680'
@@ -19,4 +21,60 @@ sudo apt update
 curl -SsL https://playit-cloud.github.io/ppa/key.gpg | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/playit.gpg >/dev/null
 echo "deb [signed-by=/etc/apt/trusted.gpg.d/playit.gpg] https://playit-cloud.github.io/ppa/data ./" | sudo tee /etc/apt/sources.list.d/playit-cloud.list
 sudo apt update
+```
+
+### Fedora
+
+```
+sudo curl -fsSL -o /etc/yum.repos.d/playit.repo https://playit-cloud.github.io/ppa/repo-files/playit-fedora.repo
+sudo dnf install playit
+```
+
+### openSUSE
+
+```
+sudo zypper ar -f https://playit-cloud.github.io/ppa/repo-files/playit-opensuse.repo
+sudo zypper refresh
+sudo zypper install playit
+```
+
+### Alpine Linux
+
+```
+sudo wget -O /etc/apk/keys/playit.rsa.pub https://playit-cloud.github.io/ppa/alpine/playit.rsa.pub
+echo "https://playit-cloud.github.io/ppa/alpine/stable/main" | sudo tee -a /etc/apk/repositories
+sudo apk update
+sudo apk add playit
+```
+
+### Maintainer Workflow
+
+Download packages for a release:
+
+```
+scripts/download-all.sh 1.0.7-rc4
+```
+
+Regenerate repository metadata:
+
+```
+scripts/update-all.sh
+```
+
+Sign repository metadata:
+
+```
+scripts/sign-all.sh
+```
+
+The existing Debian repository remains in `data/` for backwards compatibility. Fedora and openSUSE share the RPM repository at `rpm/$basearch`. Alpine uses `alpine/stable/main`.
+
+### Signing Keys
+
+Debian and RPM repository metadata use `key.gpg`.
+
+Alpine repository metadata uses the public key published at:
+
+```
+https://playit-cloud.github.io/ppa/alpine/playit.rsa.pub
 ```

--- a/repo-files/playit-fedora.repo
+++ b/repo-files/playit-fedora.repo
@@ -1,0 +1,8 @@
+[playit]
+name=playit
+baseurl=https://playit-cloud.github.io/ppa/rpm/$basearch
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://playit-cloud.github.io/ppa/key.gpg
+metadata_expire=1h

--- a/repo-files/playit-opensuse.repo
+++ b/repo-files/playit-opensuse.repo
@@ -1,0 +1,9 @@
+[playit]
+name=playit
+enabled=1
+autorefresh=1
+baseurl=https://playit-cloud.github.io/ppa/rpm/$basearch
+type=rpm-md
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://playit-cloud.github.io/ppa/key.gpg

--- a/scripts/alpine/download.sh
+++ b/scripts/alpine/download.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+REPO_ROOT=$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)
+
+VERSION="${1:-}"
+
+if [ -z "${VERSION}" ]; then
+  echo "missing version" >&2
+  exit 1
+fi
+
+BASE_URL="https://github.com/playit-cloud/playit-agent/releases/download/v${VERSION}"
+ARCHES=(x86_64 aarch64 armv7 x86)
+
+for arch in "${ARCHES[@]}"; do
+  asset="playit_${arch}.apk"
+  output_dir="${REPO_ROOT}/alpine/stable/main/${arch}"
+  output="${output_dir}/playit_${VERSION}_${arch}.apk"
+  partial="${output}.part"
+
+  mkdir -p "${output_dir}"
+
+  echo "downloading ${asset}"
+  if ! curl -fL -o "${partial}" "${BASE_URL}/${asset}"; then
+    rm -f "${partial}"
+    echo "missing Alpine asset: ${asset} for v${VERSION}" >&2
+    exit 1
+  fi
+
+  mv "${partial}" "${output}"
+done

--- a/scripts/alpine/sign.sh
+++ b/scripts/alpine/sign.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+REPO_ROOT=$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)
+ARCHES=(x86_64 aarch64 armv7 x86)
+
+if [ -z "${ALPINE_SIGNING_KEY:-}" ]; then
+  echo "missing required environment variable: ALPINE_SIGNING_KEY" >&2
+  exit 1
+fi
+
+if [ -z "${ALPINE_SIGNING_KEY_NAME:-}" ]; then
+  echo "missing required environment variable: ALPINE_SIGNING_KEY_NAME" >&2
+  exit 1
+fi
+
+for arch in "${ARCHES[@]}"; do
+  repo_dir="${REPO_ROOT}/alpine/stable/main/${arch}"
+  index="${repo_dir}/APKINDEX.tar.gz"
+
+  if [ ! -f "${index}" ]; then
+    echo "missing Alpine repository index: alpine/stable/main/${arch}/APKINDEX.tar.gz" >&2
+    exit 1
+  fi
+
+  echo "signing alpine/stable/main/${arch}/APKINDEX.tar.gz"
+  abuild-sign -k "${ALPINE_SIGNING_KEY}" -p "${ALPINE_SIGNING_KEY_NAME}" "${index}"
+done

--- a/scripts/alpine/update.sh
+++ b/scripts/alpine/update.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+REPO_ROOT=$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)
+ARCHES=(x86_64 aarch64 armv7 x86)
+
+for arch in "${ARCHES[@]}"; do
+  repo_dir="${REPO_ROOT}/alpine/stable/main/${arch}"
+
+  if [ ! -d "${repo_dir}" ]; then
+    echo "missing Alpine repository directory: alpine/stable/main/${arch}" >&2
+    exit 1
+  fi
+
+  shopt -s nullglob
+  packages=("${repo_dir}"/*.apk)
+  shopt -u nullglob
+
+  if [ "${#packages[@]}" -eq 0 ]; then
+    echo "missing Alpine packages in alpine/stable/main/${arch}" >&2
+    exit 1
+  fi
+
+  echo "updating alpine/stable/main/${arch}"
+  (
+    cd "${repo_dir}"
+    apk index --rewrite-arch "${arch}" -o APKINDEX.tar.gz ./*.apk
+  )
+done

--- a/scripts/check-deps.sh
+++ b/scripts/check-deps.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+missing=()
+
+check_command() {
+  local command_name="$1"
+
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    missing+=("${command_name}")
+  fi
+}
+
+check_command curl
+check_command dpkg-scanpackages
+check_command apt-ftparchive
+check_command gpg
+check_command createrepo_c
+check_command rpm
+check_command apk
+check_command abuild-sign
+check_command openssl
+
+if [ "${#missing[@]}" -eq 0 ]; then
+  echo "all required tools are available"
+  exit 0
+fi
+
+echo "missing required tools:" >&2
+for command_name in "${missing[@]}"; do
+  echo "  - ${command_name}" >&2
+done
+
+cat >&2 <<'EOF'
+
+Install hints:
+  Debian/Ubuntu:
+    sudo apt install curl dpkg-dev apt-utils gnupg createrepo-c rpm openssl
+
+  Fedora:
+    sudo dnf install curl dpkg-dev apt createrepo_c rpm gnupg2 apk-tools abuild openssl
+
+  Alpine:
+    sudo apk add curl dpkg apt createrepo_c rpm gnupg apk-tools abuild openssl
+
+Some package names vary by distribution. Re-run scripts/check-deps.sh after installing tools.
+EOF
+
+exit 1

--- a/scripts/debian/download.sh
+++ b/scripts/debian/download.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+REPO_ROOT=$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)
+
+VERSION="${1:-}"
+
+if [ -z "${VERSION}" ]; then
+  echo "missing version" >&2
+  exit 1
+fi
+
+BASE_URL="https://github.com/playit-cloud/playit-agent/releases/download/v${VERSION}"
+
+download_deb() {
+  local arch="$1"
+  local asset="playit_${arch}.deb"
+  local output="${REPO_ROOT}/data/playit_${VERSION}_${arch}.deb"
+  local partial="${output}.part"
+
+  echo "downloading ${asset}"
+  if ! curl -fL -o "${partial}" "${BASE_URL}/${asset}"; then
+    rm -f "${partial}"
+    echo "missing Debian asset: ${asset} for v${VERSION}" >&2
+    exit 1
+  fi
+
+  mv "${partial}" "${output}"
+}
+
+download_deb amd64
+download_deb arm64
+download_deb armhf
+download_deb i386

--- a/scripts/debian/sign.sh
+++ b/scripts/debian/sign.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+cd "${SCRIPT_DIR}/../../data"
+
+gpg --local-user DA6CD75EC2839680 -a -o Release.pgp --detach-sig Release
+gpg --local-user DA6CD75EC2839680 -a -o InRelease --clearsign Release

--- a/scripts/debian/update.sh
+++ b/scripts/debian/update.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+cd "${SCRIPT_DIR}/../../data"
+
+dpkg-scanpackages --multiversion . > Packages
+gzip -k -f Packages
+apt-ftparchive release . > Release

--- a/scripts/download-all.sh
+++ b/scripts/download-all.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+VERSION="${1:-}"
+
+if [ -z "${VERSION}" ]; then
+  echo "missing version" >&2
+  exit 1
+fi
+
+"${SCRIPT_DIR}/debian/download.sh" "${VERSION}"
+"${SCRIPT_DIR}/rpm/download.sh" "${VERSION}"
+"${SCRIPT_DIR}/alpine/download.sh" "${VERSION}"

--- a/scripts/rpm/download.sh
+++ b/scripts/rpm/download.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+REPO_ROOT=$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)
+
+VERSION="${1:-}"
+
+if [ -z "${VERSION}" ]; then
+  echo "missing version" >&2
+  exit 1
+fi
+
+BASE_URL="https://github.com/playit-cloud/playit-agent/releases/download/v${VERSION}"
+ARCHES=(x86_64 aarch64 armv7hl i386)
+
+for arch in "${ARCHES[@]}"; do
+  asset="playit_${arch}.rpm"
+  output_dir="${REPO_ROOT}/rpm/${arch}"
+  output="${output_dir}/playit_${VERSION}_${arch}.rpm"
+  partial="${output}.part"
+
+  mkdir -p "${output_dir}"
+
+  echo "downloading ${asset}"
+  if ! curl -fL -o "${partial}" "${BASE_URL}/${asset}"; then
+    rm -f "${partial}"
+    echo "missing RPM asset: ${asset} for v${VERSION}" >&2
+    exit 1
+  fi
+
+  mv "${partial}" "${output}"
+done

--- a/scripts/rpm/sign.sh
+++ b/scripts/rpm/sign.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+REPO_ROOT=$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)
+ARCHES=(x86_64 aarch64 armv7hl i386)
+RPM_GPG_KEY="${RPM_GPG_KEY:-DA6CD75EC2839680}"
+
+for arch in "${ARCHES[@]}"; do
+  repo_dir="${REPO_ROOT}/rpm/${arch}"
+  metadata="${repo_dir}/repodata/repomd.xml"
+
+  if [ ! -f "${metadata}" ]; then
+    echo "missing RPM repository metadata: rpm/${arch}/repodata/repomd.xml" >&2
+    exit 1
+  fi
+
+  shopt -s nullglob
+  packages=("${repo_dir}"/*.rpm)
+  shopt -u nullglob
+
+  if [ "${#packages[@]}" -eq 0 ]; then
+    echo "missing RPM packages in rpm/${arch}" >&2
+    exit 1
+  fi
+
+  for package in "${packages[@]}"; do
+    if ! check_output=$(rpm --checksig "${package}" 2>&1); then
+      echo "failed to verify RPM package signature: ${package}" >&2
+      echo "${check_output}" >&2
+      exit 1
+    fi
+
+    if ! grep -q "signatures OK" <<<"${check_output}"; then
+      echo "RPM package is not signed: ${package}" >&2
+      echo "${check_output}" >&2
+      exit 1
+    fi
+  done
+
+  echo "signing rpm/${arch}/repodata/repomd.xml"
+  (
+    cd "${repo_dir}"
+    gpg --local-user "${RPM_GPG_KEY}" --detach-sign --armor repodata/repomd.xml
+  )
+done

--- a/scripts/rpm/update.sh
+++ b/scripts/rpm/update.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+REPO_ROOT=$(cd -- "${SCRIPT_DIR}/../.." &>/dev/null && pwd)
+ARCHES=(x86_64 aarch64 armv7hl i386)
+
+for arch in "${ARCHES[@]}"; do
+  repo_dir="${REPO_ROOT}/rpm/${arch}"
+
+  if [ ! -d "${repo_dir}" ]; then
+    echo "missing RPM repository directory: rpm/${arch}" >&2
+    exit 1
+  fi
+
+  shopt -s nullglob
+  packages=("${repo_dir}"/*.rpm)
+  shopt -u nullglob
+
+  if [ "${#packages[@]}" -eq 0 ]; then
+    echo "missing RPM packages in rpm/${arch}" >&2
+    exit 1
+  fi
+
+  echo "updating rpm/${arch}"
+  (
+    cd "${repo_dir}"
+    createrepo_c --update .
+  )
+done

--- a/scripts/sign-all.sh
+++ b/scripts/sign-all.sh
@@ -3,4 +3,6 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
-exec "${SCRIPT_DIR}/debian/download.sh" "$@"
+"${SCRIPT_DIR}/debian/sign.sh"
+"${SCRIPT_DIR}/rpm/sign.sh"
+"${SCRIPT_DIR}/alpine/sign.sh"

--- a/scripts/sign.sh
+++ b/scripts/sign.sh
@@ -1,6 +1,6 @@
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+#!/usr/bin/env bash
+set -euo pipefail
 
-cd "${SCRIPT_DIR}/../data"
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
-gpg --local-user DA6CD75EC2839680 -a -o Release.pgp --detach-sig Release
-gpg --local-user DA6CD75EC2839680 -a -o InRelease --clearsign Release
+exec "${SCRIPT_DIR}/debian/sign.sh" "$@"

--- a/scripts/update-all.sh
+++ b/scripts/update-all.sh
@@ -3,4 +3,6 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
-exec "${SCRIPT_DIR}/debian/download.sh" "$@"
+"${SCRIPT_DIR}/debian/update.sh"
+"${SCRIPT_DIR}/rpm/update.sh"
+"${SCRIPT_DIR}/alpine/update.sh"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,7 +1,6 @@
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+#!/usr/bin/env bash
+set -euo pipefail
 
-cd "${SCRIPT_DIR}/../data"
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 
-dpkg-scanpackages --multiversion . > Packages
-gzip -k -f Packages
-apt-ftparchive release . > Release
+exec "${SCRIPT_DIR}/debian/update.sh" "$@"


### PR DESCRIPTION
## Summary
- Add download, update, and signing scripts for Debian, RPM, and Alpine package repositories.
- Add Fedora and openSUSE repo files that point to the shared RPM repository.
- Update the README with install instructions for Debian/Ubuntu, Fedora, openSUSE, and Alpine Linux.
- Add a dependency check script and mark partial download artifacts in `.gitignore`.

## Testing
- Not run (documentation and shell script changes only).
- Checked the updated script layout and wrapper entrypoints for Debian, RPM, and Alpine workflows.
- Verified the new repo file targets and repository paths described in the README.