### PR TITLE
Update README for deprecated PPA notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,28 @@
-## The Offical Playit PPA
+> [!WARNING]
+> This PPA is deprecated in favor of the new package repository at https://packages.playit.gg.
+> We will continue publishing this PPA, but updates may be released more slowly here.
+
+## The Official Playit PPA
 
 To install playit on a debian based operating system simply run
 
-```
-curl -SsL https://playit-cloud.github.io/ppa/key.gpg | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/playit.gpg >/dev/null
-echo "deb [signed-by=/etc/apt/trusted.gpg.d/playit.gpg] https://playit-cloud.github.io/ppa/data ./" | sudo tee /etc/apt/sources.list.d/playit-cloud.list
+```sh
+curl -SsL https://packages.playit.gg/keys/playit.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/playit.gpg >/dev/null
+sudo chmod 0644 /usr/share/keyrings/playit.gpg
+sudo curl -fsSL -o /etc/apt/sources.list.d/playit.list https://packages.playit.gg/repo-files/playit-debian.list
 sudo apt update
 sudo apt install playit
 ```
 
-Getting a warning in apt about playit's repo? Run these commands
+Getting a warning in apt about the deprecated playit PPA? Run these commands to remove the old repository before installing from packages.playit.gg:
 
-```
+```sh
 sudo apt-key del '16AC CC32 BD41 5DCC 6F00  D548 DA6C D75E C283 9680'
 sudo rm /etc/apt/sources.list.d/playit-cloud.list
 sudo apt update
 
-curl -SsL https://playit-cloud.github.io/ppa/key.gpg | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/playit.gpg >/dev/null
-echo "deb [signed-by=/etc/apt/trusted.gpg.d/playit.gpg] https://playit-cloud.github.io/ppa/data ./" | sudo tee /etc/apt/sources.list.d/playit-cloud.list
+curl -SsL https://packages.playit.gg/keys/playit.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/playit.gpg >/dev/null
+sudo chmod 0644 /usr/share/keyrings/playit.gpg
+sudo curl -fsSL -o /etc/apt/sources.list.d/playit.list https://packages.playit.gg/repo-files/playit-debian.list
 sudo apt update
 ```


### PR DESCRIPTION
## Summary
- Added a prominent warning that the legacy Playit PPA is deprecated in favor of `packages.playit.gg`.
- Updated the install instructions to use the new repository, key location, and repo list file.
- Clarified the recovery steps for users currently on the deprecated PPA before switching to the new repository.

## Testing
- Not run (documentation-only change).
- Verified the README diff for updated commands and repository URLs.